### PR TITLE
[test] SSD Read/Write 기능 구현 - RED

### DIFF
--- a/ssd/src/main/java/Controller.java
+++ b/ssd/src/main/java/Controller.java
@@ -1,0 +1,5 @@
+public class Controller {
+    public static void main(String[] args) {
+        
+    }
+}

--- a/ssd/src/main/java/Driver.java
+++ b/ssd/src/main/java/Driver.java
@@ -1,0 +1,6 @@
+public interface Driver {
+
+    String read(String file);
+
+    void write(String file, byte[] bytes);
+}

--- a/ssd/src/main/java/FileDriver.java
+++ b/ssd/src/main/java/FileDriver.java
@@ -1,0 +1,11 @@
+public class FileDriver implements Driver {
+    @Override
+    public String read(String file) {
+        return "";
+    }
+
+    @Override
+    public void write(String file, byte[] bytes) {
+
+    }
+}

--- a/ssd/src/main/java/ReadWritable.java
+++ b/ssd/src/main/java/ReadWritable.java
@@ -1,0 +1,5 @@
+public interface ReadWritable {
+    void read(int address);
+
+    void write(int address, String value);
+}

--- a/ssd/src/main/java/Ssd.java
+++ b/ssd/src/main/java/Ssd.java
@@ -1,0 +1,11 @@
+public class Ssd implements ReadWritable {
+    @Override
+    public void read(int address) {
+
+    }
+
+    @Override
+    public void write(int address, String value) {
+
+    }
+}

--- a/ssd/src/test/java/SsdTest.java
+++ b/ssd/src/test/java/SsdTest.java
@@ -1,35 +1,177 @@
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class SsdTest {
+    public static final String WRITE_TEST_VALUE = "0xFFFFFFF0";
+    public static final int WRITE_TEST_ADDRESS = 88;
+    public static final int READ_TEST_ADDRESS = 33;
+    public static final String NO_WRITE_VALUE = "0x00000000";
+    public static final String SSD_OUTPUT_TXT = "ssd_output.txt";
 
+    @Mock
+    Driver fileDriver;
+
+    Ssd ssd;
+
+    @BeforeEach
+    void setUp() {
+        ssd = new Ssd();
+
+        File file = new File(SSD_OUTPUT_TXT);
+        if (file.exists()) file.delete();
+
+
+        File nand_file = new File("ssd_nand.txt");
+        if (nand_file.exists()) nand_file.delete();
+    }
+
+    @AfterEach
+    void cleanup() {
+        File output_file = new File(SSD_OUTPUT_TXT);
+        if (output_file.exists()) output_file.delete();
+
+        File nand_file = new File("ssd_nand.txt");
+        if (nand_file.exists()) nand_file.delete();
+    }
 
     //Write Test
     @Test
     void LBA_영역_값_쓰기_ssd_nand_txt_미존재() {
+
+        //Arrange
+        doAnswer(invocation -> {
+            try (FileOutputStream fileOutputStream = new FileOutputStream("ssd_nand.txt")) {
+                fileOutputStream.write(WRITE_TEST_VALUE.getBytes());
+            }
+            return null;
+        }).when(fileDriver).write(anyString(), any());
+
+        //Act
+        ssd.write(WRITE_TEST_ADDRESS, WRITE_TEST_VALUE);
+
+        //Assert
+        verify(fileDriver, times(1)).write(anyString(), any());
+        assertTrue(new File("ssd_nand.txt").exists(), "파일이 생성되지 않았습니다.");
     }
 
 
     @Test
-    void LBA_영역_값_쓰기_ssd_nand_txt_존재() {
+    void LBA_영역_값_쓰기_ssd_nand_txt_존재() throws IOException {
+
+        //Arrange
+        try (FileOutputStream fileOutputStream = new FileOutputStream(SSD_OUTPUT_TXT)) {
+            fileOutputStream.write("test".getBytes());
+        }
+        File expectFile = new File("ssd_nand.txt");
+
+        doAnswer(invocation -> {
+            try (FileOutputStream fileOutputStream = new FileOutputStream("ssd_nand.txt")) {
+                fileOutputStream.write(WRITE_TEST_VALUE.getBytes());
+                return null;
+            }
+        }).when(fileDriver).write(anyString(), any());
+
+        //Act
+        ssd.write(WRITE_TEST_ADDRESS, WRITE_TEST_VALUE);
+
+        //Assert
+        verify(fileDriver, times(1)).write(anyString(), any());
+        assertTrue(expectFile.exists(), "파일이 생성되지 않았습니다.");
     }
 
 
-    //Read TEst
+    //Read Test
     @Test
-    void 기록한적_있는_LBA영역_읽기() {
-        //• Read 명령어는 ssd_nand.txt에서 데이터를 읽고,
-        //읽은 데이터를 ssd_output.txt 파일에 기록한다.
+    void 기록한적_있는_LBA영역_읽기() throws IOException {
+
+        //Arrange
+        doAnswer(invocation -> {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(SSD_OUTPUT_TXT)) {
+                fileOutputStream.write(WRITE_TEST_VALUE.getBytes());
+                return null;
+            }
+        }).when(fileDriver).read(anyString());
+
+        //Act
+        ssd.read(READ_TEST_ADDRESS);
+
+        //Assert
+        verify(fileDriver, times(1)).read(anyString());
+        assertThat(new String(Files.readAllBytes(Paths.get(SSD_OUTPUT_TXT)))).isEqualTo(WRITE_TEST_VALUE);
     }
 
     @Test
-    void 기록한적_없는_LBA영역_읽기() {
-        //• 기록이 한적이 없는 LBA를 읽으면 0x00000000 으로 읽힌다.
+        //기록이 한적이 없는 LBA를 읽으면 0x00000000 으로 읽힌다.
+    void 기록한적_없는_LBA영역_읽기() throws IOException {
+
+        //Arrange
+        doAnswer(invocation -> {
+            try (FileOutputStream fileOutputStream = new FileOutputStream(SSD_OUTPUT_TXT)) {
+                fileOutputStream.write(NO_WRITE_VALUE.getBytes());
+                return null;
+            }
+        }).when(fileDriver).read(anyString());
+
+        //Act
+        ssd.read(READ_TEST_ADDRESS);
+
+        //Assert
+        verify(fileDriver, times(1)).read(anyString());
+        String content = new String(Files.readAllBytes(Paths.get(SSD_OUTPUT_TXT))); // 기본 UTF-8로 변환
+        assertThat(content).isEqualTo(NO_WRITE_VALUE);
     }
 
     @Test
-    void 같은_LBA영역_다른_값_쓰고_읽기_두번() {
-        //    • ssd_output.txt에는 항상 마지막 Read 명령어에 대한 수행 결과가 저장되어있다.
-        //    즉, 덮어쓰기 방식으로 파일에 읽은 값을 기록한다.
-    }
+    void 같은_LBA영역_다른_값_쓰고_읽기_여러번() throws IOException {
 
+        //Arrange
+        int retryCnt = 3;
+        doAnswer(invocation -> {
+            String path = invocation.getArgument(0);
+            byte[] data = invocation.getArgument(1);
+            Files.write(Paths.get(SSD_OUTPUT_TXT), data);
+            return null;
+        }).when(fileDriver).write(anyString(), any());
+
+        doAnswer(invocation -> {
+            byte[] data = Files.readAllBytes(Paths.get(SSD_OUTPUT_TXT));
+            try (FileOutputStream fos = new FileOutputStream(SSD_OUTPUT_TXT)) {
+                fos.write(data);
+                return null;
+            }
+        }).when(fileDriver).read(anyString());
+
+        //Act
+        List<String> readStringList = new ArrayList<>();
+        for (int i = 0; i < retryCnt; i++) {
+            ssd.write(WRITE_TEST_ADDRESS, WRITE_TEST_VALUE + i);
+            ssd.read(WRITE_TEST_ADDRESS);
+            readStringList.add(Files.readString(Paths.get(SSD_OUTPUT_TXT)));
+        }
+
+        //Assert
+        for (int i = 0; i < readStringList.size(); i++) {
+            assertThat(readStringList.get(i)).isEqualTo(String.valueOf(WRITE_TEST_VALUE + i));
+        }
+        verify(fileDriver, times(retryCnt)).write(anyString(), any());
+        verify(fileDriver, times(retryCnt)).read(anyString());
+    }
 }

--- a/ssd/src/test/java/SsdTest.java
+++ b/ssd/src/test/java/SsdTest.java
@@ -1,0 +1,35 @@
+import org.junit.jupiter.api.Test;
+
+class SsdTest {
+
+
+    //Write Test
+    @Test
+    void LBA_영역_값_쓰기_ssd_nand_txt_미존재() {
+    }
+
+
+    @Test
+    void LBA_영역_값_쓰기_ssd_nand_txt_존재() {
+    }
+
+
+    //Read TEst
+    @Test
+    void 기록한적_있는_LBA영역_읽기() {
+        //• Read 명령어는 ssd_nand.txt에서 데이터를 읽고,
+        //읽은 데이터를 ssd_output.txt 파일에 기록한다.
+    }
+
+    @Test
+    void 기록한적_없는_LBA영역_읽기() {
+        //• 기록이 한적이 없는 LBA를 읽으면 0x00000000 으로 읽힌다.
+    }
+
+    @Test
+    void 같은_LBA영역_다른_값_쓰고_읽기_두번() {
+        //    • ssd_output.txt에는 항상 마지막 Read 명령어에 대한 수행 결과가 저장되어있다.
+        //    즉, 덮어쓰기 방식으로 파일에 읽은 값을 기록한다.
+    }
+
+}


### PR DESCRIPTION
### 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

SSD 모듈 TDD RED 단계로 테스트구현하였습니다.

- 5개 Test 항목
1. LBA_영역_값_쓰기_ssd_nand_txt_미존재
2. LBA_영역_값_쓰기_ssd_nand_txt_존재
3. 기록한적_있는_LBA영역_읽기
4. 기록한적_없는_LBA영역_읽기
5. 같은_LBA영역_다른_값_쓰고_읽기_여러번


### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
→ RED 단계 입니다.

- [ ] Unit Test 100% Pass 여부
→ RED 단계로 모두 Fail입니다.

### 📸 스크린샷 (선택)
💬 공유사항 to 리뷰어

현재 ssd와 filedriver에서 read동작시 return이 없고 ssd_output.txt 파일에 결과가 생겨 동작 검증외에 확인할 방법이 없습니다.

이에 test 코드 내에서 미리 파일을 생성하거나 stub으로 파일을 생성하게 구현하였습니다.
 
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
