### PR TITLE
Logger의 결과 파일들이 log 디렉토리에서 관리되도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### File ###
-/ssd/*.txt
+ssd/*.txt
+log/
 
 .gradle
 build/

--- a/test-shell/src/main/java/driver/Driver.java
+++ b/test-shell/src/main/java/driver/Driver.java
@@ -5,6 +5,8 @@ import java.util.function.Supplier;
 
 public interface Driver {
 
+    void createDirectoryIfAbsent(String directoryName);
+
     void append(String file, byte[] bytes);
 
     void changeOldLogFileName(String latestLogFileName);

--- a/test-shell/src/main/java/driver/Driver.java
+++ b/test-shell/src/main/java/driver/Driver.java
@@ -5,10 +5,6 @@ import java.util.function.Supplier;
 
 public interface Driver {
 
-    String read(String file);
-
-    void write(String file, byte[] bytes);
-
     void append(String file, byte[] bytes);
 
     void changeOldLogFileName(String latestLogFileName);

--- a/test-shell/src/main/java/driver/FileDriver.java
+++ b/test-shell/src/main/java/driver/FileDriver.java
@@ -13,30 +13,6 @@ public class FileDriver implements Driver {
     public static final String LOG_EXTENSION_POSTFIX = ".log";
 
     @Override
-    public String read(String file) {
-        requireValidFileName(file);
-
-        try {
-            return Files.readString(Paths.get(file));
-        } catch (NoSuchFileException e) {
-            throw new RuntimeException("File Not Found: " + file);
-        } catch (IOException e) {
-            throw new RuntimeException("Not Expected Error");
-        }
-    }
-
-    @Override
-    public void write(String file, byte[] bytes) {
-        requireValidFileName(file);
-
-        try {
-            Files.write(Paths.get(file), bytes, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @Override
     public void append(String file, byte[] bytes) {
         requireValidFileName(file);
 

--- a/test-shell/src/main/java/driver/FileDriver.java
+++ b/test-shell/src/main/java/driver/FileDriver.java
@@ -13,13 +13,25 @@ public class FileDriver implements Driver {
     public static final String LOG_EXTENSION_POSTFIX = ".log";
 
     @Override
+    public void createDirectoryIfAbsent(String directoryName) {
+        Path dirPath = Path.of(directoryName);
+        if (Files.exists(dirPath) && Files.isDirectory(dirPath)) return;
+
+        try {
+            Files.createDirectory(dirPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Not Expected Error");
+        }
+    }
+
+    @Override
     public void append(String file, byte[] bytes) {
         requireValidFileName(file);
 
         try {
             Files.write(Paths.get(file), bytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Not Expected Error");
         }
     }
 
@@ -57,7 +69,7 @@ public class FileDriver implements Driver {
         }
     }
 
-//    @VisibleForTesting
+    //    @VisibleForTesting
     void convertToZipFile(String oldLogFileName) {
         try {
             String zipFileName = oldLogFileName.replace(".log", ".zip");

--- a/test-shell/src/main/java/logger/Logger.java
+++ b/test-shell/src/main/java/logger/Logger.java
@@ -19,11 +19,14 @@ public class Logger {
     public static final String LATEST_LOG_FILE_NAME = "latest.log";
     private static final long TEST_LOG_MAX_SIZE = 10 * 1024 * 1024;
     public static final String LINE_BREAK = "\n";
+    public static final String LOG_DIRECTORY_NAME = "log";
+    public static final String LATEST_FILE_FULL_PATH = LOG_DIRECTORY_NAME + "/" + LATEST_LOG_FILE_NAME;
 
     private final Driver fileDriver;
 
     private Logger() {
         this.fileDriver = new FileDriver();
+        this.fileDriver.createDirectoryIfAbsent(LOG_DIRECTORY_NAME);
     }
 
     // @VisibleForTesting
@@ -41,9 +44,9 @@ public class Logger {
     }
 
     private void printAndManageLogFile(String fullMessage) {
-        fileDriver.append(LATEST_LOG_FILE_NAME, fullMessage.getBytes(StandardCharsets.UTF_8));
-        fileDriver.changeNameIfBiggerThan(TEST_LOG_MAX_SIZE, LATEST_LOG_FILE_NAME, this::makeOldLogFileName);
-        fileDriver.changeOldLogFileName(LATEST_LOG_FILE_NAME);
+        fileDriver.append(LATEST_FILE_FULL_PATH, fullMessage.getBytes(StandardCharsets.UTF_8));
+        fileDriver.changeNameIfBiggerThan(TEST_LOG_MAX_SIZE, LATEST_FILE_FULL_PATH, this::makeOldLogFileName);
+        fileDriver.changeOldLogFileName(LATEST_FILE_FULL_PATH);
     }
 
     private String makeFullMessage(String methodFullName, String logMessage) {

--- a/test-shell/src/test/java/logger/LoggerTest.java
+++ b/test-shell/src/test/java/logger/LoggerTest.java
@@ -37,7 +37,7 @@ class LoggerTest {
 
         verify(driver, times(1)).append(any(), any());
         verify(driver, times(1)).changeNameIfBiggerThan(anyLong(), anyString(), any());
-        verify(driver, times(1)).changeOldLogFileName(Logger.LATEST_LOG_FILE_NAME);
+        verify(driver, times(1)).changeOldLogFileName(Logger.LATEST_FILE_FULL_PATH);
     }
 
     @Test

--- a/test-shell/src/test/java/utils/LogFileDeleter.java
+++ b/test-shell/src/test/java/utils/LogFileDeleter.java
@@ -1,0 +1,25 @@
+package utils;
+
+import logger.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+public class LogFileDeleter {
+    public static void deleteRecursivelyLogDirectory() throws IOException {
+        Path directoryToDelete = Path.of(Logger.LOG_DIRECTORY_NAME);
+
+        if (Files.exists(directoryToDelete)) {
+            Files.walk(directoryToDelete)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        }
+    }
+}


### PR DESCRIPTION
### 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
```
Logger의 결과 파일들이 log 디렉토리에서 관리되도록 수정하였습니다.
불필요한 API 삭제하여 리팩토링한 내용도 존재합니다.
```

### ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Unit Test 100% Pass 여부

### 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
Logger 사용하는 방향으로 모듈 내 구현 시 테스트 코드 수행하면 log 디렉토리가 사라지지 않을것으로 예상됩니다.
아래 @AfterEach 를 통해 삭제하는 방향으로 조치하면 좋을 것 같습니다.
도영님 리뷰로 test용 Util로 LogFileDeleter 클래스를 만들었으니 아래와 같이 사용해주시면 됩니다 !
```
    @AfterEach
    void cleanUp() throws IOException {
        LogFileDeleter.deleteRecursivelyLogDirectory();
    }
```